### PR TITLE
[Feat] 프로필 설정 뷰 생성

### DIFF
--- a/Where.xcodeproj/project.pbxproj
+++ b/Where.xcodeproj/project.pbxproj
@@ -39,6 +39,9 @@
 		04832B4C2D2675EF003FFE3B /* FriendsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04832B4B2D2675EF003FFE3B /* FriendsListView.swift */; };
 		04832B522D26A55B003FFE3B /* WhereTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04832B512D26A55B003FFE3B /* WhereTabView.swift */; };
 		049345142D229E10003D1129 /* BasedFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049345132D229E10003D1129 /* BasedFormView.swift */; };
+		91B7A16F2D26DFC2003932B4 /* ProfileCreationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B7A16D2D26DFC2003932B4 /* ProfileCreationView.swift */; };
+		91B7A1702D26DFC2003932B4 /* ProfilePopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B7A16E2D26DFC2003932B4 /* ProfilePopupView.swift */; };
+		91B7A1722D26DFDE003932B4 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B7A1712D26DFDE003932B4 /* String.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,6 +90,9 @@
 		04832B4B2D2675EF003FFE3B /* FriendsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsListView.swift; sourceTree = "<group>"; };
 		04832B512D26A55B003FFE3B /* WhereTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhereTabView.swift; sourceTree = "<group>"; };
 		049345132D229E10003D1129 /* BasedFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasedFormView.swift; sourceTree = "<group>"; };
+		91B7A16D2D26DFC2003932B4 /* ProfileCreationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCreationView.swift; sourceTree = "<group>"; };
+		91B7A16E2D26DFC2003932B4 /* ProfilePopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePopupView.swift; sourceTree = "<group>"; };
+		91B7A1712D26DFDE003932B4 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -156,6 +162,7 @@
 			children = (
 				045B44B72D2164E800514A27 /* DesignSystem */,
 				045B44EB2D224D1D00514A27 /* Color Extension.swift */,
+				91B7A1712D26DFDE003932B4 /* String.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -171,7 +178,8 @@
 		045B44A32D2150AF00514A27 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				045B44B12D21517D00514A27 /* Splash.storyboard */,
+				91B7A16D2D26DFC2003932B4 /* ProfileCreationView.swift */,
+				91B7A16E2D26DFC2003932B4 /* ProfilePopupView.swift */,
 				045B44ED2D224D5C00514A27 /* OnboardingView.swift */,
 				045B44F32D22889000514A27 /* LoginView.swift */,
 				04832B282D22A6D7003FFE3B /* SignInView.swift */,
@@ -179,6 +187,7 @@
 				04832B302D23D63D003FFE3B /* AthentificationView.swift */,
 				04832B4B2D2675EF003FFE3B /* FriendsListView.swift */,
 				04832B342D23F765003FFE3B /* FloaterView.swift */,
+				045B44B12D21517D00514A27 /* Splash.storyboard */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -373,6 +382,7 @@
 				045B44A82D2150AF00514A27 /* Model.swift in Sources */,
 				04832B2B2D22AA82003FFE3B /* RoundedTextField.swift in Sources */,
 				045B44BA2D21650200514A27 /* Pretendard.swift in Sources */,
+				91B7A1722D26DFDE003932B4 /* String.swift in Sources */,
 				04832B4C2D2675EF003FFE3B /* FriendsListView.swift in Sources */,
 				045B44A92D2150AF00514A27 /* Service.swift in Sources */,
 				045B44F62D228DC000514A27 /* RoundedProminentButtonStyle.swift in Sources */,
@@ -394,6 +404,8 @@
 				04832B332D23EB93003FFE3B /* Floater.swift in Sources */,
 				049345142D229E10003D1129 /* BasedFormView.swift in Sources */,
 				045B44EE2D224D5C00514A27 /* OnboardingView.swift in Sources */,
+				91B7A16F2D26DFC2003932B4 /* ProfileCreationView.swift in Sources */,
+				91B7A1702D26DFC2003932B4 /* ProfilePopupView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Where/Utility/String.swift
+++ b/Where/Utility/String.swift
@@ -1,0 +1,46 @@
+//
+//  String.swift
+//  Where
+//
+//  Created by 이현호 on 12/30/24.
+//
+
+extension String {
+    // 문자열에 이모지가 포함되어 있는지 확인
+    var containsEmoji: Bool {
+        for character in self {
+            if character.isEmoji {
+                return true
+            }
+        }
+        return false
+    }
+}
+
+extension Character {
+    // 한 문자가 이모지인지 여부를 확인
+    var isEmoji: Bool {
+        guard let scalar = self.unicodeScalars.first else { return false }
+        return scalar.isEmoji
+    }
+}
+
+extension UnicodeScalar {
+    // 이모지 여부를 확인
+    var isEmoji: Bool {
+        return (self.value >= 0x1F600 && self.value <= 0x1F64F) || // Emoticons
+               (self.value >= 0x1F300 && self.value <= 0x1F5FF) || // Miscellaneous Symbols and Pictographs
+               (self.value >= 0x1F680 && self.value <= 0x1F6FF) || // Transport and Map Symbols
+               (self.value >= 0x1F700 && self.value <= 0x1F77F) || // Alchemical Symbols
+               (self.value >= 0x1F780 && self.value <= 0x1F7FF) || // Geometric Shapes Extended
+               (self.value >= 0x1F800 && self.value <= 0x1F8FF) || // Supplemental Symbols and Pictographs
+               (self.value >= 0x1F900 && self.value <= 0x1F9FF) || // Supplemental Symbols and Pictographs
+               (self.value >= 0x1FA00 && self.value <= 0x1FA6F) || // Chess Symbols
+               (self.value >= 0x1FA70 && self.value <= 0x1FAFF) || // Symbols and Pictographs Extended
+               (self.value >= 0x2600 && self.value <= 0x26FF) ||   // Miscellaneous Symbols
+               (self.value >= 0x2700 && self.value <= 0x27BF) ||   // Dingbats
+               (self.value == 0x2B50) ||                         // Star
+               (self.value == 0x2B06) ||                         // Upwards Button
+               (self.value == 0x2B07)                           // Downwards Button
+    }
+}

--- a/Where/Views/ProfileCreationView.swift
+++ b/Where/Views/ProfileCreationView.swift
@@ -1,0 +1,145 @@
+//
+//  ProfileCreationView.swift
+//  Where
+//
+//  Created by 이현호 on 12/29/24.
+//
+
+import SwiftUI
+
+struct ProfileCreationView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State var username: String = ""
+    @State private var isValid: Bool = false
+    @State private var showPopup = false
+    @State private var profileImage: UIImage? = UIImage(named: "person")
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                VStack {
+                    HStack {
+                        Text("프로필을 설정해주세요")
+                            .font(.system(size: 24.0))
+                            .fontWeight(.bold)
+                        Spacer()
+                    }
+                    .padding(.top, 40)
+                    .padding(.horizontal)
+                    
+                    ZStack(alignment: .bottomTrailing) {
+                        if let image = profileImage {
+                            Image(uiImage: image)
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 155, height: 155)
+                                .clipShape(Circle())
+                        }
+                        Button {
+                            withAnimation {
+                                showPopup = true
+                            }
+                        } label: {
+                            Image("CameraButton")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 40, height: 40)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                    }
+                    .padding(.top, 58)
+                    
+                    HStack {
+                        Text("닉네임")
+                        Spacer()
+                    }
+                    .padding(.top, 38)
+                    .padding(.horizontal)
+                    
+                    ZStack(alignment: .trailing) {
+                        // 팝업창
+                        TextField("",
+                                  text: $username,
+                                  prompt: Text("닉네임을 입력해주세요").foregroundStyle(Color(hex: 0x6B7280))
+                        )
+                        .frame(height: 56)
+                        .textFieldStyle(PlainTextFieldStyle())
+                        .padding([.horizontal], 15)
+                        .overlay(RoundedRectangle(cornerRadius: 12).stroke(isValid ? Color.green : Color(hex: 0xE5E7EB)))
+                        .padding(.horizontal)
+                        .onChange(of: username) { newValue in
+                            // 텍스트 필드가 비어 있으면 isValid를 false로 설정
+                            if newValue.isEmpty {
+                                isValid = false
+                            } else {
+                                // 8자 이상 입력 제한
+                                let maxLength = 8
+                                let filteredValue = newValue.filter { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }
+                                
+                                // 8자 이상일 경우 8자까지만 잘라내기
+                                username = String(filteredValue.prefix(maxLength))
+                                
+                                // 유효성 검사: 특수문자, 이모지 제외
+                                isValid = username.count <= maxLength && !username.containsEmoji && username.allSatisfy {
+                                    $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_"
+                                }
+                            }
+                        }
+                        
+                        // 체크 아이콘
+                        if isValid {
+                            Image(systemName: "checkmark")
+                                .foregroundColor(.green)
+                                .padding(.trailing, 30)
+                        }
+                    }
+                    
+                    
+                    HStack {
+                        Text(isValid ? "사용 가능한 닉네임입니다" : "8자 내, 이모지, 특수문자(-,_제외)를 사용할 수 없습니다.")
+                            .font(.system(size: 14))
+                            .foregroundColor(isValid ? .green : .black)  // 유효성에 따라 색상 변경
+                            .padding(.horizontal)
+                        
+                        Spacer()
+                    }
+                    
+                    Spacer()
+                    
+                    Button {
+                        // 버튼 클릭 시 동작할 코드
+                    } label: {
+                        Text("다음")
+                            .frame(maxWidth: .infinity)
+                            .padding()  // 버튼 내부 여백
+                            .background(Color(hex: 0x4F46E5))  // 배경색 설정
+                            .foregroundStyle(.white)  // 텍스트 색을 흰색으로 설정
+                            .bold()
+                            .cornerRadius(10)  // 둥근 모서리
+                    }
+                    .padding()
+                }
+                
+                if showPopup {
+                    ProfilePopupView(showPopup: $showPopup, profileImage: $profileImage)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "arrow.backward")
+                            .frame(width: 14, height: 12)
+                            .foregroundStyle(.black)
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+#Preview {
+    ProfileCreationView()
+}

--- a/Where/Views/ProfilePopupView.swift
+++ b/Where/Views/ProfilePopupView.swift
@@ -1,0 +1,72 @@
+//
+//  ProfileCreationPopUpView.swift
+//  Where
+//
+//  Created by LHH on 12/30/24.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct ProfilePopupView: View {
+    @Binding var showPopup: Bool
+    @Binding var profileImage: UIImage?
+    @State private var selectedItem: PhotosPickerItem?
+    
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(Color.black.opacity(0.4)) // 배경을 어두운 반투명 색으로 설정
+                .ignoresSafeArea()
+            
+            VStack(alignment: .leading, spacing: 20) {
+                Button("기본 이미지로 설정") {
+                    profileImage = UIImage(named: "person")
+                    showPopup = false
+                }
+                .padding(.top,20)
+                .padding(.leading)
+                .foregroundStyle(Color.black)
+                
+                PhotosPicker(
+                    selection: $selectedItem,
+                    matching: .images,
+                    photoLibrary: .shared()
+                ) {
+                    Text("앨범에서 사진 선택")
+                        .padding()
+                        .foregroundStyle(Color.black)
+                }
+                .onChange(of: selectedItem) { newItem in
+                    Task {
+                        if let data = try? await newItem?.loadTransferable(type: Data.self),
+                           let uiImage = UIImage(data: data) {
+                            profileImage = uiImage
+                            showPopup = false
+                        }
+                    }
+                }
+                
+                Rectangle()
+                    .fill(Color.gray)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .overlay(
+                        Text("취소")
+                            .bold()
+                            .foregroundStyle(Color.white)
+                    )
+                
+                    .onTapGesture {
+                        showPopup = false
+                    }
+            }
+            .padding()
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .frame(width: 300) // 팝업의 가로 크기 설정
+            .shadow(radius: 10) // 그림자 효과 추가
+        }
+    }
+}


### PR DESCRIPTION
# [Feat] 프로필 설정 뷰 생성

## 개요
프로필 설정, 앨범에서 이미지 추가, 닉네임 유효성 체크, 닉네임 생성 시 색상 변동

* 일단 공통적으로 쓰이는 요소는 개발 당시 정해진 사항이 없어 하드코딩한 점 양해부탁드립니다. 추후 리팩토링하겠습니다.

---

## 구현사항

### 1. 프로필 설정 시 앨범에서 사진 선택
**iOS16 이상으로 한다는 가정하에 PhotosPicker 사용했습니다.**

```swift
PhotosPicker(
    selection: $selectedItem,
    matching: .images,
    photoLibrary: .shared()
) {
    Text("앨범에서 사진 선택")
        .padding()
        .foregroundStyle(Color.black)
}
.onChange(of: selectedItem) { newItem in
    Task {
        if let data = try? await newItem?.loadTransferable(type: Data.self),
           let uiImage = UIImage(data: data) {
            profileImage = uiImage
            showPopup = false
        }
    }
}
```

### 2. 컬러
**Hex Code 사용을 위해 Extension을 추가하였습니다.**

```swift
extension Color {
    init(hex: UInt, alpha: Double = 1) {
        self.init(
            .sRGB,
            red: Double((hex >> 16) & 0xff) / 255,
            green: Double((hex >> 08) & 0xff) / 255,
            blue: Double((hex >> 00) & 0xff) / 255,
            opacity: alpha
        )
    }
}
```

### 3. 문자열 이모지 유효성 체크
**닉네임 설정 시 유효성 체크를 위해 String Extension을 추가했습니다. 따로 사용하시는 부분이 있으면 하나로 통일 시켜 사용해야할 것 같습니다.**

### 4. 폰트
**폰트는 기본 Font로 사용하고 있어 Merge 후 Pretendard로 리팩토링해두겠습니다.**


---
