### PR TITLE
[Feat]: 장소상세 페이지

### DIFF
--- a/Where.xcodeproj/project.pbxproj
+++ b/Where.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		91F1BFC92D3B8093000B4C84 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F1BFC82D3B8093000B4C84 /* BackButton.swift */; };
 		91F6CE402D3D75DB00BD24D1 /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F6CE3F2D3D75DB00BD24D1 /* CommentView.swift */; };
 		91F6CE422D3D786F00BD24D1 /* PlaceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F6CE412D3D786F00BD24D1 /* PlaceInfo.swift */; };
+		91F6CE442D3D7B3100BD24D1 /* PlaceDelete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F6CE432D3D7B3100BD24D1 /* PlaceDelete.swift */; };
 		F70F76C82D2FBB1E006EFF2D /* NewImagePopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70F76C72D2FBB1E006EFF2D /* NewImagePopupView.swift */; };
 		F70F76CA2D2FC00A006EFF2D /* NewMeetingSheet2View.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70F76C92D2FC00A006EFF2D /* NewMeetingSheet2View.swift */; };
 		F75400962D310EF5009D201F /* NewFriendListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75400952D310EF5009D201F /* NewFriendListView.swift */; };
@@ -138,6 +139,7 @@
 		91F1BFC82D3B8093000B4C84 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		91F6CE3F2D3D75DB00BD24D1 /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
 		91F6CE412D3D786F00BD24D1 /* PlaceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceInfo.swift; sourceTree = "<group>"; };
+		91F6CE432D3D7B3100BD24D1 /* PlaceDelete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceDelete.swift; sourceTree = "<group>"; };
 		F70F76C72D2FBB1E006EFF2D /* NewImagePopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewImagePopupView.swift; sourceTree = "<group>"; };
 		F70F76C92D2FC00A006EFF2D /* NewMeetingSheet2View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMeetingSheet2View.swift; sourceTree = "<group>"; };
 		F75400952D310EF5009D201F /* NewFriendListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewFriendListView.swift; sourceTree = "<group>"; };
@@ -417,6 +419,7 @@
 				91F1BFC62D3B7F95000B4C84 /* PlaceDetail.swift */,
 				91F6CE412D3D786F00BD24D1 /* PlaceInfo.swift */,
 				91F6CE3F2D3D75DB00BD24D1 /* CommentView.swift */,
+				91F6CE432D3D7B3100BD24D1 /* PlaceDelete.swift */,
 			);
 			path = Place;
 			sourceTree = "<group>";
@@ -575,6 +578,7 @@
 				91F1BFC72D3B7F95000B4C84 /* PlaceDetail.swift in Sources */,
 				045B44AD2D2150AF00514A27 /* ContentView.swift in Sources */,
 				046833F52D3B8F99009D2357 /* User.swift in Sources */,
+				91F6CE442D3D7B3100BD24D1 /* PlaceDelete.swift in Sources */,
 				045B44AE2D2150AF00514A27 /* WhereApp.swift in Sources */,
 				045B44CB2D216AA700514A27 /* View+Pretendard.swift in Sources */,
 				048182272D29151800CCF721 /* AsyncDateView.swift in Sources */,

--- a/Where/Views/Place/CommentView.swift
+++ b/Where/Views/Place/CommentView.swift
@@ -9,66 +9,64 @@ import SwiftUI
 
 struct CommentView: View {
     var body: some View {
-        ScrollView {
-            VStack {
-                HStack(spacing: 4) {
-                    Text("코멘트")
-                    
-                    Text("2")
-                    
-                    Spacer()
-                }
-                .whereFont(.body16medium)
+        VStack {
+            HStack(spacing: 4) {
+                Text("코멘트")
                 
-                VStack {
-                    HStack {
-                        Text("여기 웨이팅 맛집임")
-                            .whereFont(.body14regular)
-                            .foregroundStyle(.black)
-                            .padding(.vertical, 10)
-                            .padding(.horizontal, 16)
-                            .background(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .stroke(Color(hex: 0x4F46E5), lineWidth: 1)
-                            )
-                        
-                        Spacer()
-                    }
-                    
-                    HStack {
-                        Text("여기 야경 맛집임")
-                            .whereFont(.body14regular)
-                            .foregroundStyle(.black)
-                            .padding(.vertical, 10)
-                            .padding(.horizontal, 16)
-                            .background(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .stroke(Color(hex: 0xE3E4E9), lineWidth: 1)
-                            )
-                        
-                        Spacer()
-                    }
-                    
-                    HStack {
-                        Text("그냥 그럼")
-                            .whereFont(.body14regular)
-                            .foregroundStyle(.black)
-                            .padding(.vertical, 10)
-                            .padding(.horizontal, 16)
-                            .background(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .stroke(Color(hex: 0xE3E4E9), lineWidth: 1)
-                            )
-                        
-                        Spacer()
-                    }
-                }
-                .padding(.top, 16)
+                Text("2")
                 
                 Spacer()
             }
-            .padding(.horizontal, 20)
+            .whereFont(.body16medium)
+            
+            VStack {
+                HStack {
+                    Text("여기 웨이팅 맛집임")
+                        .whereFont(.body14regular)
+                        .foregroundStyle(.black)
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 16)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color(hex: 0x4F46E5), lineWidth: 1)
+                        )
+                    
+                    Spacer()
+                }
+                
+                HStack {
+                    Text("여기 야경 맛집임")
+                        .whereFont(.body14regular)
+                        .foregroundStyle(.black)
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 16)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color(hex: 0xE3E4E9), lineWidth: 1)
+                        )
+                    
+                    Spacer()
+                }
+                
+                HStack {
+                    Text("그냥 그럼")
+                        .whereFont(.body14regular)
+                        .foregroundStyle(.black)
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 16)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color(hex: 0xE3E4E9), lineWidth: 1)
+                        )
+                    
+                    Spacer()
+                }
+            }
+            .padding(.top, 16)
+            
+            Spacer()
         }
+        .padding(.horizontal, 20)
     }
 }
 

--- a/Where/Views/Place/PlaceDelete.swift
+++ b/Where/Views/Place/PlaceDelete.swift
@@ -1,0 +1,30 @@
+//
+//  PlaceDelete.swift
+//  Where
+//
+//  Created by 이현호 on 1/20/25.
+//
+
+import SwiftUI
+
+struct PlaceDelete: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Button {
+            
+            } label: {
+                Text("장소 삭제")
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 54)
+                    .background(Color(hex: 0xF3F4F6))
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+            .padding(.horizontal, 20)
+        }
+    }
+}
+
+#Preview {
+    PlaceDelete()
+}

--- a/Where/Views/Place/PlaceDetail.swift
+++ b/Where/Views/Place/PlaceDetail.swift
@@ -9,206 +9,215 @@ import SwiftUI
 
 struct PlaceDetail: View {
     @State private var isPlacePick = false
+    @State private var showDeleteSheet = false
     
     var body: some View {
         NavigationStack {
-            VStack {
-                ZStack(alignment: .topLeading) {
-                    // 장소 정보
-                    PlaceInfo(imageName: "ExampleImage", name: "무드서울", address: "서울 용산구 한강대로21길 18 1층")
-                    
-                    RoundedRectangle(cornerSize: .init(width: 17, height: 17))
-                        .overlay {
-                            HStack {
-                                Text("같이 찾은 장소")
-                                    .whereFont(.caption11regular)
-                                    .foregroundStyle(.white)
-                            }
-                        }
-                        .frame(width: 71, height: 19)
-                        .foregroundStyle(Color(hex: 0x4F46E5))
-                        .padding(.leading, 10)
-                        .padding(.top, 10)
-                }
-                
-                HStack {
-                    // 코멘트
-                    HStack(spacing: 1) {
-                        Image(systemName: "message")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 12, height: 12)
+            ScrollView {
+                VStack {
+                    ZStack(alignment: .topLeading) {
+                        // 장소 정보
+                        PlaceInfo(imageName: "ExampleImage", name: "무드서울", address: "서울 용산구 한강대로21길 18 1층")
                         
-                        Text("코멘트")
-                            .whereFont(.body14medium)
-                            .padding(.leading, 4)
-                        
-                        Text("4")
-                            .whereFont(.body14medium)
-                            .padding(.leading, 2)
-                    }
-                    .foregroundStyle(Color(hex: 0x868E96))
-                    .padding(.top, 12)
-                    
-                    //  좋아요
-                    HStack(spacing: 1) {
-                        Image(systemName: "heart.fill")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 12, height: 12)
-                        
-                        Text("코멘트")
-                            .whereFont(.body14medium)
-                            .padding(.leading, 4)
-                        
-                        Text("1")
-                            .whereFont(.body14medium)
-                            .padding(.leading, 2)
-                    }
-                    .foregroundStyle(Color(hex: 0x4F46E5))
-                    .padding(.top, 12)
-                    .padding(.leading, 12)
-                }
-                
-                HStack {
-                    // 네이버 지도 버튼
-                    Button {
-                        // 네이버 지도 이동
-                    } label: {
-                        HStack {
-                            Spacer()
-                            Image("NaverMapLogo")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 20, height: 20)
-                            
-                            Text("네이버지도")
-                                .whereFont(.body14regular)
-                                .foregroundStyle(.black)
-                            
-                            Spacer()
-                            
-                        }
-                        .padding()
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 48)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 30)
-                                .stroke(Color(hex: 0xE3E4E9), lineWidth: 1)
-                        )
-                    }
-                    
-                    // 카카오맵 버튼
-                    Button {
-                        // 카카오맵 이동
-                    } label: {
-                        HStack {
-                            Spacer()
-                            Image("KakaoMapLogo")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 20, height: 20)
-                            
-                            Text("카카오맵")
-                                .whereFont(.body14regular)
-                                .foregroundStyle(.black)
-                            
-                            Spacer()
-                            
-                        }
-                        .padding()
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 48)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 30)
-                                .stroke(Color(hex: 0xE3E4E9), lineWidth: 1)
-                        )
-                    }
-                }
-                
-                RoundedRectangle(cornerSize: .init(width: 16, height: 16))
-                    .overlay {
-                        ZStack {
-                            HStack {
+                        RoundedRectangle(cornerSize: .init(width: 17, height: 17))
+                            .overlay {
                                 HStack {
-                                    Text("이 장소로 ")
-                                        .foregroundStyle(.black)
-                                    + Text("Pick")
-                                        .foregroundStyle(Color(hex: 0x4F46E5))
-                                    + Text("할까요?")
-                                        .foregroundStyle(.black)
+                                    Text("같이 찾은 장소")
+                                        .whereFont(.caption11regular)
+                                        .foregroundStyle(.white)
                                 }
-                                .whereFont(.body16medium)
-                                .foregroundStyle(.black)
+                            }
+                            .frame(width: 71, height: 19)
+                            .foregroundStyle(Color(hex: 0x4F46E5))
+                            .padding(.leading, 10)
+                            .padding(.top, 10)
+                    }
+                    
+                    HStack {
+                        // 코멘트
+                        HStack(spacing: 1) {
+                            Image(systemName: "message")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 12, height: 12)
+                            
+                            Text("코멘트")
+                                .whereFont(.body14medium)
+                                .padding(.leading, 4)
+                            
+                            Text("4")
+                                .whereFont(.body14medium)
+                                .padding(.leading, 2)
+                        }
+                        .foregroundStyle(Color(hex: 0x868E96))
+                        .padding(.top, 12)
+                        
+                        // 좋아요
+                        HStack(spacing: 1) {
+                            Image(systemName: "heart.fill")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 12, height: 12)
+                            
+                            Text("좋아요")
+                                .whereFont(.body14medium)
+                                .padding(.leading, 4)
+                            
+                            Text("1")
+                                .whereFont(.body14medium)
+                                .padding(.leading, 2)
+                        }
+                        .foregroundStyle(Color(hex: 0x4F46E5))
+                        .padding(.top, 12)
+                        .padding(.leading, 12)
+                    }
+                    
+                    HStack {
+                        // 네이버 지도 버튼
+                        Button {
+                            // 네이버 지도 이동
+                        } label: {
+                            HStack {
+                                Spacer()
+                                Image("NaverMapLogo")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 20, height: 20)
+                                
+                                Text("네이버지도")
+                                    .whereFont(.body14regular)
+                                    .foregroundStyle(.black)
                                 
                                 Spacer()
                                 
-                                Button {
-                                    withAnimation {
-                                        isPlacePick.toggle()
-                                    }
-                                } label: {
-                                    if isPlacePick {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .resizable()
-                                            .aspectRatio(contentMode: .fit)
-                                            .frame(width: 32, height: 32)
-                                            .foregroundStyle(Color(hex: 0x4F46E5))
-                                    } else {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .resizable()
-                                            .aspectRatio(contentMode: .fit)
-                                            .frame(width: 32, height: 32)
-                                            .foregroundStyle(Color(hex: 0xDEE2E6))
-                                    }
-                                }
                             }
-                            .padding(.horizontal, 16)
-                            
-                            if !isPlacePick {
-                                Image("PickTooltip")
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 30)
+                                    .stroke(Color(hex: 0xE3E4E9), lineWidth: 1)
+                            )
+                        }
+                        
+                        // 카카오맵 버튼
+                        Button {
+                            // 카카오맵 이동
+                        } label: {
+                            HStack {
+                                Spacer()
+                                Image("KakaoMapLogo")
                                     .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 230, height: 42)
-                                    .padding(.top, 80)
-                                    .padding(.leading, 87)
+                                    .scaledToFit()
+                                    .frame(width: 20, height: 20)
+                                
+                                Text("카카오맵")
+                                    .whereFont(.body14regular)
+                                    .foregroundStyle(.black)
+                                
+                                Spacer()
+                                
                             }
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 30)
+                                    .stroke(Color(hex: 0xE3E4E9), lineWidth: 1)
+                            )
                         }
                     }
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 64)
-                    .foregroundStyle(Color(hex: 0xF9FAFB))
-                    .transition(.opacity)
                     .padding(.top, 32)
-                
-                Spacer()
-            }
-            .padding(.horizontal, 20)
-            .padding(.top, 32)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    BackButton()
+                    
+                    RoundedRectangle(cornerSize: .init(width: 16, height: 16))
+                        .overlay {
+                            ZStack {
+                                HStack {
+                                    HStack {
+                                        Text("이 장소로 ")
+                                            .foregroundStyle(.black)
+                                        + Text("Pick")
+                                            .foregroundStyle(Color(hex: 0x4F46E5))
+                                        + Text("할까요?")
+                                            .foregroundStyle(.black)
+                                    }
+                                    .whereFont(.body16medium)
+                                    .foregroundStyle(.black)
+                                    
+                                    Spacer()
+                                    
+                                    Button {
+                                        withAnimation {
+                                            isPlacePick.toggle()
+                                        }
+                                    } label: {
+                                        if isPlacePick {
+                                            Image(systemName: "checkmark.circle.fill")
+                                                .resizable()
+                                                .aspectRatio(contentMode: .fit)
+                                                .frame(width: 32, height: 32)
+                                                .foregroundStyle(Color(hex: 0x4F46E5))
+                                        } else {
+                                            Image(systemName: "checkmark.circle.fill")
+                                                .resizable()
+                                                .aspectRatio(contentMode: .fit)
+                                                .frame(width: 32, height: 32)
+                                                .foregroundStyle(Color(hex: 0xDEE2E6))
+                                        }
+                                    }
+                                }
+                                .padding(.horizontal, 16)
+                                
+                                if !isPlacePick {
+                                    Image("PickTooltip")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: 230, height: 42)
+                                        .padding(.top, 80)
+                                        .padding(.leading, 100)
+                                }
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 64)
+                        .foregroundStyle(Color(hex: 0xF9FAFB))
+                        .transition(.opacity)
+                        .padding(.top, 32)
+                    
+                    Spacer()
                 }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Text("삭제")
-                            .whereFont(.body16medium)
+                .padding(.horizontal, 20)
+                .padding(.top, 32)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        BackButton()
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            showDeleteSheet = true
+                        } label: {
+                            Text("삭제")
+                                .whereFont(.body16medium)
+                        }
                     }
                 }
+                .sheet(isPresented: $showDeleteSheet) {
+                    PlaceDelete()
+                        .presentationDetents([.height(148)])
+                        .presentationCornerRadius(16)
+                }
+                
+                VStack {
+                    Rectangle()
+                        .foregroundStyle(Color(hex: 0xF1F3F5))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 8)
+                        .padding(.top, 31)
+                }
+                
+                // 코멘트 Part
+                CommentView()
             }
-            
-            VStack {
-                Rectangle()
-                    .foregroundStyle(Color(hex: 0xF1F3F5))
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 8)
-                    .padding(.top, 31)
-            }
-            
-            // 코멘트 Part
-            CommentView()
         }
     }
 }


### PR DESCRIPTION
# [Feat] 장소 상세 뷰 생성

## 개요
장소 상세 뷰 생성

---

## 구현사항

### 1. 사진 및 가게명, 주소 부분
- 추후 지도 API에서 사진 불러올 예정
- 같이 찾은 장소는 2명 이상 선택했을 때 로직 추가 해야함

### 2. 코멘트, 좋아요
- 추후 코멘트, 좋아요 숫자 연동 

### 3. 네이버지도, 카카오맵 버튼
- 버튼 클릭 시 외부 앱 이동 로직 추가 예정

### 4. Tooltip 부분 (이 장소를 정했다면 Pick을 눌러주세요!)
- 말풍선 이미지 커스텀이 어려워 전체 이미지로 가져옴
- Check 버튼 아래로 위치하기 위해 Padding으로 조절 → Auto Layout 확인 예정 (단말기 별로 위치 상이한 지 확인)

```swift
// 글자수 카운트
if !isPlacePick {
	Image("PickTooltip")
	    .resizable()
	    .aspectRatio(contentMode: .fit)
	    .frame(width: 230, height: 42)
	    .padding(.top, 80)
	    .padding(.leading, 100)
}
```

### 5. 코멘트 부분
- 수정 및 삭제 부분 미완성
- 전체 화면 스크롤로 변경

## Todo
- 코드 리팩토링 → 전체적으로 가독성이 떨어짐
- 지도 API 추가
- 네이버지도, 카카오맵 버튼 클릭 시 외부 앱 이동 로직 추가 예정
- 코멘트, 좋아요 숫자 연동
- 코멘트 수정, 삭제 디자인 요청
- Check 버튼 아래로 위치하기 위해 Padding으로 조절 → Auto Layout 확인 예정 (단말기 별로 위치 상이한 지 확인)
- 같이 찾은 장소는 2명 이상 선택했을 때 로직 추가 해야함
